### PR TITLE
Make FP16 blobs support FP32 inputs.

### DIFF
--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -27,7 +27,7 @@
 // <float16,float> for Intel
 // <float16,float16> for ARM
 
-//#define NATIVE_FP16_SUPPORTED 1
+#define NATIVE_FP16_SUPPORTED 1
 
 #if NATIVE_FP16_SUPPORTED
 # define CAFFE_FP16_MTYPE float16

--- a/src/caffe/blob.cpp
+++ b/src/caffe/blob.cpp
@@ -593,14 +593,27 @@ void Blob<float16,CAFFE_FP16_MTYPE>::FromProto(const BlobProto& proto, bool resh
     CHECK(ShapeEquals(proto)) << "shape mismatch (reshape not set)";
   }
   // copy data
-  if (proto.half_data_size() > 0) {
+  if (proto.data_size() > 0) {
+    CHECK_EQ(count_, proto.data_size());
+    float16* data_vec = mutable_cpu_data();
+    for (int i = 0; i < count_; ++i) {
+      data_vec[i] = Get<float16>(proto.data(i));
+    } 
+  } else if (proto.half_data_size() > 0) {
     float16* data_vec = mutable_cpu_data();
     CHECK_EQ(count_, proto.half_data_size());
     for (int i = 0; i < count_; ++i) {
       data_vec[i].setx(proto.half_data(i));
     }
   }
-  if (proto.half_diff_size() > 0) {
+  if (proto.diff_size() > 0) {
+    CHECK_EQ(count_, proto.diff_size());
+    float16* diff_vec = mutable_cpu_diff();
+    for (int i = 0; i < count_; ++i) {
+      diff_vec[i] = Get<float16>(proto.half_diff(i));
+    }
+  }
+  else if (proto.half_diff_size() > 0) {
     CHECK_EQ(count_, proto.half_diff_size());
     float16* diff_vec = mutable_cpu_diff();
     for (int i = 0; i < count_; ++i) {
@@ -617,7 +630,7 @@ INSTANTIATE_CLASS(Blob);
 #if NATIVE_FP16_SUPPORTED
 //template class Blob<float16,float16>;
 #else
-//template class Blob<float16,float>;
+template class Blob<float16,float>;
 #endif
 #endif // CPU_ONLY
 


### PR DESCRIPTION
The FP16 blob specialization of FromProto was not able to read FP32. It
is a potential issue when you work with FP32 proto buffers. This commit
adds the support for FP32 inputs in the FromProto member function of the
blob class.
