### PR TITLE
Exclude pause instruction from __aarch64__

### DIFF
--- a/3rdparty/cub/cub/host/spinlock.cuh
+++ b/3rdparty/cub/cub/host/spinlock.cuh
@@ -88,9 +88,9 @@ namespace cub {
      */
     __forceinline__ void YieldProcessor()
     {
-#ifndef __arm__
+#if !defined(__arm__) && !defined(__aarch64__)
         asm volatile("pause\n": : :"memory");
-#endif  // __arm__
+#endif  // __arm__ && __aarch64__
     }
 
 #endif  // defined(_MSC_VER)


### PR DESCRIPTION
Exclude pause instruction from **aarch64** (similar to **arm**) because none of ARM and ARM64 supprt this operation. This enables compiler to compile Caffe on L4T 24.1 which is aarch64.
